### PR TITLE
fix typo in pom.xml

### DIFF
--- a/week3/exo301/pom.xml
+++ b/week3/exo301/pom.xml
@@ -1,6 +1,6 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" 
-  xmlns:xsi="http://www.w3.org2001/XMLSchema-instance"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apahe.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
       


### PR DESCRIPTION
Fixed typo in **pom.xml project tag** leading to errors:
- _URI is not registered (Settings | Languages & Frameworks | Schemas and DTDs)_ for xmlns:xsi value
- _Attribute xsi:schemaLocation is not allowed here_ for xsi:schemaLocation attribute

Cause: missing slash in w3 URI